### PR TITLE
Table retention strategy

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -25,7 +25,7 @@ Valid values:
 
 ---
 
-## `Cronus:Projections:Cassandra:TableRetention:DeleteOldProjectionTables` >> *boolean | Required: No | Default: false*
+## `Cronus:Projections:Cassandra:TableRetention:DeleteOldProjectionTables` >> *boolean | Required: No | Default: true*
 
 ---
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,32 @@
+# Cronus.Projections.Cassandra
+
+## `Cronus:Projections:Cassandra:ConnectionString` >> *string | Required: Yes*
+
+The connection to the Cassandra database server
+
+---
+
+## `Cronus:Projections:Cassandra:ReplicationStrategy` >> *string | Required: No | Default: simple*
+
+Configures Cassandra replication strategy. This setting has effect only in the first run when creating the database.
+
+Valid values:
+
+* simple
+* network_topology - when using this setting you need to specify `Cronus:Projections:Cassandra:ReplicationFactor` and `Cronus:Projections:Cassandra:Datacenters` as well
+
+---
+
+## `Cronus:Projections:Cassandra:ReplicationFactor` >> *integer | Required: No | Default: 1*
+
+---
+
+## `Cronus:Projections:Cassandra:Datacenters` >> *string[] | Required: No*
+
+---
+
+## `Cronus:Projections:Cassandra:TableRetention:DeleteOldProjectionTables` >> *boolean | Required: No | Default: false*
+
+---
+
+## `Cronus:Projections:Cassandra:TableRetention:NumberOfOldProjectionTablesToRetain` >> *unsigned integer | Required: No | Default: 2*

--- a/src/Elders.Cronus.Projections.Cassandra.Tests/When_bulding_snapshot_column_family_from_version.cs
+++ b/src/Elders.Cronus.Projections.Cassandra.Tests/When_bulding_snapshot_column_family_from_version.cs
@@ -2,16 +2,16 @@
 
 namespace Elders.Cronus.Projections.Cassandra.Tests
 {
-    public class When_bulding_projection_column_family_from_version
+    public class When_bulding_snapshot_column_family_from_version
     {
         Establish context = () =>
         {
             version = new ProjectionVersion("projName", ProjectionStatus.Live, 2, "hash");
         };
 
-        Because of = () => columnFamily = naming.GetColumnFamily(version);
+        Because of = () => columnFamily = naming.GetSnapshotColumnFamily(version);
 
-        It should_create_column_family = () => columnFamily.ShouldEqual("projname_2_hash");
+        It should_create_column_family = () => columnFamily.ShouldEqual("projname_2_hash_sp");
 
         static VersionedProjectionsNaming naming = new VersionedProjectionsNaming();
         static ProjectionVersion version;

--- a/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family.cs
+++ b/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family.cs
@@ -1,0 +1,32 @@
+﻿using Machine.Specifications;
+
+namespace Elders.Cronus.Projections.Cassandra.Tests
+{
+    public class When_parsing_version_from_column_family
+    {
+        Establish context = () =>
+        {
+            projectionName = "projname";
+            revision = 2;
+            hash = "hash";
+            columnFamily = $"{projectionName}_{revision}_{hash}";
+        };
+
+        Because of = () => version = naming.Parse(columnFamily);
+
+        It should_parse_version = () => version.ShouldNotBeNull();
+
+        It should_parse_projection_name = () => version.ProjectionName.ShouldEqual(projectionName);
+
+        It should_parse_revision = () => version.Revision.ShouldEqual(revision);
+
+        It should_parse_hash = () => version.Hash.ShouldEqual(hash);
+
+        static VersionedProjectionsNaming naming = new VersionedProjectionsNaming();
+        static ProjectionVersion version;
+        static string columnFamily;
+        static string projectionName;
+        static int revision;
+        static string hash;
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family_with_invalid_revision.cs
+++ b/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family_with_invalid_revision.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Machine.Specifications;
+
+namespace Elders.Cronus.Projections.Cassandra.Tests
+{
+    public class When_parsing_version_from_column_family_with_invalid_revision
+    {
+        Establish context = () =>
+        {
+            columnFamily = $"projname_hash_2";
+        };
+
+        Because of = () => ex = Catch.Exception(() => version = naming.Parse(columnFamily));
+
+        It should_not_parse_version = () => version.ShouldBeNull();
+
+        It should_throw = () => ex.ShouldNotBeNull();
+
+        static VersionedProjectionsNaming naming = new VersionedProjectionsNaming();
+        static ProjectionVersion version;
+        static string columnFamily;
+        static Exception ex;
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family_with_less_than_3_parts.cs
+++ b/src/Elders.Cronus.Projections.Cassandra.Tests/When_parsing_version_from_column_family_with_less_than_3_parts.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Machine.Specifications;
+
+namespace Elders.Cronus.Projections.Cassandra.Tests
+{
+    public class When_parsing_version_from_column_family_with_less_than_3_parts
+    {
+        Establish context = () =>
+        {
+            columnFamily = $"projname_2";
+        };
+
+        Because of = () => ex = Catch.Exception(() => version = naming.Parse(columnFamily));
+
+        It should_not_parse_version = () => version.ShouldBeNull();
+
+        It should_throw = () => ex.ShouldNotBeNull();
+
+        static VersionedProjectionsNaming naming = new VersionedProjectionsNaming();
+        static ProjectionVersion version;
+        static string columnFamily;
+        static Exception ex;
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra.sln
+++ b/src/Elders.Cronus.Projections.Cassandra.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29926.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elders.Cronus.Projections.Cassandra", "Elders.Cronus.Projections.Cassandra\Elders.Cronus.Projections.Cassandra.csproj", "{EE46D4DA-D6F4-4AED-840E-9E4C0FE3A467}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elders.Cronus.Projections.Cassandra.Tests", "Elders.Cronus.Projections.Cassandra.Tests\Elders.Cronus.Projections.Cassandra.Tests.csproj", "{1ED67B67-253A-4C38-8A8B-BBDF6329FF5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elders.Cronus.Projections.Cassandra.Tests", "Elders.Cronus.Projections.Cassandra.Tests\Elders.Cronus.Projections.Cassandra.Tests.csproj", "{1ED67B67-253A-4C38-8A8B-BBDF6329FF5F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Elders.Cronus.Projections.Cassandra.sln
+++ b/src/Elders.Cronus.Projections.Cassandra.sln
@@ -12,6 +12,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{1A91CF2F-1
 		..\docs\Configuration.md = ..\docs\Configuration.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{E978F8AF-8E96-49DF-8C47-CC0C357C1B4F}"
+	ProjectSection(SolutionItems) = preProject
+		Elders.Cronus.Projections.Cassandra\Cronus.Projections.Cassandra.rn.md = Elders.Cronus.Projections.Cassandra\Cronus.Projections.Cassandra.rn.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Elders.Cronus.Projections.Cassandra.sln
+++ b/src/Elders.Cronus.Projections.Cassandra.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elders.Cronus.Projections.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elders.Cronus.Projections.Cassandra.Tests", "Elders.Cronus.Projections.Cassandra.Tests\Elders.Cronus.Projections.Cassandra.Tests.csproj", "{1ED67B67-253A-4C38-8A8B-BBDF6329FF5F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{1A91CF2F-10CF-46AB-A13F-A53C16C5BAB2}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\Configuration.md = ..\docs\Configuration.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Elders.Cronus.Projections.Cassandra/CassandraProjectionStoreSchema.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/CassandraProjectionStoreSchema.cs
@@ -35,6 +35,8 @@ namespace Elders.Cronus.Projections.Cassandra
             if (lockTtl == TimeSpan.Zero) throw new ArgumentException("Lock ttl must be more than 0", nameof(lockTtl));
         }
 
+        public string Keyspace => sessionForSchemaChanges.Keyspace;
+
         public void DropTable(string location)
         {
             if (@lock.Lock(location, lockTtl))

--- a/src/Elders.Cronus.Projections.Cassandra/CassandraSnapshotStoreSchema.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/CassandraSnapshotStoreSchema.cs
@@ -33,6 +33,8 @@ namespace Elders.Cronus.Projections.Cassandra
             if (lockTtl == TimeSpan.Zero) throw new ArgumentException("Lock ttl must be more than 0", nameof(lockTtl));
         }
 
+        public string Keyspace => sessionForSchemaChanges.Keyspace;
+
         public void DropTable(string location)
         {
             if (string.IsNullOrWhiteSpace(location)) throw new ArgumentNullException(nameof(location));

--- a/src/Elders.Cronus.Projections.Cassandra/IProjectionsNamingStrategy.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/IProjectionsNamingStrategy.cs
@@ -4,5 +4,6 @@
     {
         string GetColumnFamily(ProjectionVersion version);
         string GetSnapshotColumnFamily(ProjectionVersion version);
+        ProjectionVersion Parse(string columnFamily);
     }
 }

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/IProjectionTableRetentionStrategy.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/IProjectionTableRetentionStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Elders.Cronus.Projections.Cassandra.Infrastructure
+{
+    public interface IProjectionTableRetentionStrategy
+    {
+        void Apply(ProjectionVersion currentProjectionVersion);
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/ProjectionVersionHandler.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/ProjectionVersionHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+using Elders.Cronus.Projections.Versioning;
+
+namespace Elders.Cronus.Projections.Cassandra.Infrastructure
+{
+    [DataContract(Name = "a25d65d4-7172-43be-9ebe-9b3a5c8928a0")]
+    public class ProjectionVersionHandler : ISystemProjection,
+        IEventHandler<NewProjectionVersionIsNowLive>
+    {
+        private readonly IProjectionTableRetentionStrategy strategy;
+
+        public ProjectionVersionHandler(IProjectionTableRetentionStrategy strategy)
+        {
+            this.strategy = strategy;
+        }
+
+        public void Handle(NewProjectionVersionIsNowLive @event)
+        {
+            strategy.Apply(@event.ProjectionVersion);
+        }
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/RetainOldProjectionRevisions.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/RetainOldProjectionRevisions.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace Elders.Cronus.Projections.Cassandra.Infrastructure
 {
-    public class RetainOnlyNewestProjectionRevisions : IProjectionTableRetentionStrategy
+    public class RetainOldProjectionRevisions : IProjectionTableRetentionStrategy
     {
         private readonly ICluster cluster;
         private readonly IProjectionsNamingStrategy projectionsNaming;
@@ -13,7 +13,7 @@ namespace Elders.Cronus.Projections.Cassandra.Infrastructure
         private readonly CassandraSnapshotStoreSchema snapshotsSchema;
         private TableRetentionOptions options;
 
-        public RetainOnlyNewestProjectionRevisions(ICluster cluster, IProjectionsNamingStrategy projectionsNaming, CassandraProjectionStoreSchema projectionsSchema, CassandraSnapshotStoreSchema snapshotsSchema, IOptionsMonitor<TableRetentionOptions> optionsMonitor)
+        public RetainOldProjectionRevisions(ICluster cluster, IProjectionsNamingStrategy projectionsNaming, CassandraProjectionStoreSchema projectionsSchema, CassandraSnapshotStoreSchema snapshotsSchema, IOptionsMonitor<TableRetentionOptions> optionsMonitor)
         {
             this.cluster = cluster;
             this.projectionsNaming = projectionsNaming;

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/RetainOnlyNewestProjectionRevisions.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/RetainOnlyNewestProjectionRevisions.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cassandra;
+using Microsoft.Extensions.Options;
+
+namespace Elders.Cronus.Projections.Cassandra.Infrastructure
+{
+    public class RetainOnlyNewestProjectionRevisions : IProjectionTableRetentionStrategy
+    {
+        private readonly ICluster cluster;
+        private readonly IProjectionsNamingStrategy projectionsNaming;
+        private readonly CassandraProjectionStoreSchema projectionsSchema;
+        private readonly CassandraSnapshotStoreSchema snapshotsSchema;
+        private TableRetentionOptions options;
+
+        public RetainOnlyNewestProjectionRevisions(ICluster cluster, IProjectionsNamingStrategy projectionsNaming, CassandraProjectionStoreSchema projectionsSchema, CassandraSnapshotStoreSchema snapshotsSchema, IOptionsMonitor<TableRetentionOptions> optionsMonitor)
+        {
+            this.cluster = cluster;
+            this.projectionsNaming = projectionsNaming;
+            this.projectionsSchema = projectionsSchema;
+            this.snapshotsSchema = snapshotsSchema;
+            options = optionsMonitor.CurrentValue;
+            optionsMonitor.OnChange(newOptions => options = newOptions);
+        }
+
+        public void Apply(ProjectionVersion currentProjectionVersion)
+        {
+            if (options.DeleteOldProjectionTables == false)
+                return;
+
+            var latestRevisionToRetain = currentProjectionVersion.Revision - options.NumberOfOldProjectionTablesToRetain;
+            if (latestRevisionToRetain <= 0)
+                return;
+
+            var projectionsVersionsToDelete = GetProjectionVersions(projectionsSchema.Keyspace);
+            foreach (var version in projectionsVersionsToDelete)
+            {
+                var projectionTableName = projectionsNaming.GetColumnFamily(version);
+                projectionsSchema.DropTable(projectionTableName);
+            }
+
+            var projectionsVersionsSnapshotsToDelete = GetProjectionVersions(snapshotsSchema.Keyspace);
+            foreach (var version in projectionsVersionsSnapshotsToDelete)
+            {
+                var snapshotTableName = projectionsNaming.GetSnapshotColumnFamily(version);
+                snapshotsSchema.DropTable(snapshotTableName);
+            }
+
+            IEnumerable<ProjectionVersion> GetProjectionVersions(string keyspace)
+            {
+                var projectionsTables = cluster.Metadata.GetTables(keyspace);
+                var projectionsVersionsToDelete = projectionsTables
+                    .Select(x => projectionsNaming.Parse(x))
+                    .Where(x => x.ProjectionName == currentProjectionVersion.ProjectionName && x.Revision < latestRevisionToRetain); // handles cases when the hash might change
+
+                return projectionsVersionsToDelete;
+            }
+        }
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptions.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Elders.Cronus.Projections.Cassandra.Infrastructure
+{
+    public class TableRetentionOptions
+    {
+        public bool DeleteOldProjectionTables { get; set; } = false;
+        public uint NumberOfOldProjectionTablesToRetain { get; set; } = 2;
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptions.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptions.cs
@@ -2,7 +2,7 @@
 {
     public class TableRetentionOptions
     {
-        public bool DeleteOldProjectionTables { get; set; } = false;
+        public bool DeleteOldProjectionTables { get; set; } = true;
         public uint NumberOfOldProjectionTablesToRetain { get; set; } = 2;
     }
 }

--- a/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptionsProvider.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/Infrastructure/TableRetention/TableRetentionOptionsProvider.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Elders.Cronus.Projections.Cassandra.Infrastructure
+{
+    public class TableRetentionOptionsProvider : CronusOptionsProviderBase<TableRetentionOptions>
+    {
+        public const string SettingKey = "cronus:projections:cassandra:tableretention";
+
+        public TableRetentionOptionsProvider(IConfiguration configuration) : base(configuration) { }
+
+        public override void Configure(TableRetentionOptions options)
+        {
+            configuration.GetSection(SettingKey).Bind(options);
+        }
+    }
+}

--- a/src/Elders.Cronus.Projections.Cassandra/ProjectionLoaderDiscovery.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/ProjectionLoaderDiscovery.cs
@@ -14,7 +14,8 @@ namespace Elders.Cronus.Projections.Cassandra
     {
         protected override DiscoveryResult<IProjectionReader> DiscoverFromAssemblies(DiscoveryContext context)
         {
-            return new DiscoveryResult<IProjectionReader>(GetModels(context), services => services.AddOptions<CassandraProviderOptions, CassandraProviderOptionsProvider>());
+            return new DiscoveryResult<IProjectionReader>(GetModels(context), services => services.AddOptions<CassandraProviderOptions, CassandraProviderOptionsProvider>()
+                                                                                                  .AddOptions<TableRetentionOptions, TableRetentionOptionsProvider>());
         }
 
         IEnumerable<DiscoveredModel> GetModels(DiscoveryContext context)

--- a/src/Elders.Cronus.Projections.Cassandra/VersionedProjectionsNaming.cs
+++ b/src/Elders.Cronus.Projections.Cassandra/VersionedProjectionsNaming.cs
@@ -15,6 +15,18 @@ namespace Elders.Cronus.Projections.Cassandra
             return $"{GetColumnFamily(version)}_sp";
         }
 
+        public ProjectionVersion Parse(string columnFamily)
+        {
+            var parts = columnFamily.Split('_');
+            if (parts.Length < 3)
+                throw new ArgumentException($"Unable to parse '{nameof(ProjectionVersion)}' from '{columnFamily}'.", nameof(columnFamily));
+
+            if (int.TryParse(parts[1], out var revision) == false)
+                throw new ArgumentException($"Invalid projection revision '{parts[1]}'.", nameof(columnFamily));
+
+            return new ProjectionVersion(parts[0], ProjectionStatus.Create("unknown"), revision, parts[2]);
+        }
+
         string NormalizeProjectionName(string projectionName)
         {
             return projectionName.Replace("-", "").ToLower();


### PR DESCRIPTION
# Title
Table retention strategy

## Related Issue 
Closes Elders/Cronus#148

### Description
A configurable strategy for deleting old projections tables. The strategy kicks in after the `NewProjectionVersionIsNowLive` event is handled. The default `RetainOnlyNewestProjectionRevisions` strategy deletes projections and snapshots tables below the configured revision, regardless of the versions hash. New strategies can be plugged-in by implementing the `IProjectionTableRetentionStrategy` interface.

### Test Methods
Parsing a projection version from a column family