### PR TITLE
Release 6.1.1

### DIFF
--- a/src/Elders.Cronus.Projections.Cassandra/Cronus.Projections.Cassandra.rn.md
+++ b/src/Elders.Cronus.Projections.Cassandra/Cronus.Projections.Cassandra.rn.md
@@ -1,3 +1,6 @@
+#### 6.1.1 - 24.09.2020
+* Starts using GetSession from CassandraProvider instead of local copies for connections
+
 #### 6.1.0 - 24.08.2020
 * Updates packages
 

--- a/src/Elders.Cronus.Projections.Cassandra/Cronus.Projections.Cassandra.rn.md
+++ b/src/Elders.Cronus.Projections.Cassandra/Cronus.Projections.Cassandra.rn.md
@@ -1,5 +1,6 @@
 #### 6.1.1 - 24.09.2020
 * Starts using GetSession from CassandraProvider instead of local copies for connections
+* Updates Cronus packaget to 6.1.1
 
 #### 6.1.0 - 24.08.2020
 * Updates packages

--- a/src/Elders.Cronus.Projections.Cassandra/Elders.Cronus.Projections.Cassandra.csproj
+++ b/src/Elders.Cronus.Projections.Cassandra/Elders.Cronus.Projections.Cassandra.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cronus" Version="6.1.0" />
+    <PackageReference Include="Cronus" Version="6.1.1" />
     <PackageReference Include="CassandraCSharpDriver" Version="3.15.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.7" />
   </ItemGroup>


### PR DESCRIPTION
# Title
Starts using GetSession from CassandraProvider instead of local copies for connections

## Related Issue 
No related issue

### Description
In the multiple files where ISession was being used, under specific circumstances the session could time-out or get disposed. The sessions are managed by the CassandraProvider implementation, which is singletonPerTenant. All classes that used ISession directly now use the CassandraProvider in order to have their session resolved.

### Test Methods
I have executed this on a long-running process which waits for the general 5-minute timeout and then attempts to load a tenant-projection. The projection loaded successfully, unlike the way it did before. More test cases should be done, please advise if you have any ideas